### PR TITLE
Tweak sampleArray type signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sampleEachSecond(of(2))
 
 ```
 
-#### sampleArray :: (a → b → [c]) → Stream a → Stream b → [Stream c]
+#### sampleArray :: (a → [b] → c) → Stream a → [Stream b] → Stream c
 
 ```
 s1:                             -2--3-4--2--5--6---7---1->


### PR DESCRIPTION
I think this is correct: the sampler function for sampleArray accepts an `a` and an array of `b`s and returns a `c`.
